### PR TITLE
Fix links leading to nonexisting pages

### DIFF
--- a/vitepress/docs/src/pages/firmware_guide/configure_firmware.md
+++ b/vitepress/docs/src/pages/firmware_guide/configure_firmware.md
@@ -45,7 +45,7 @@ Double check that you have correctly entered your WiFi credentials and that said
 
 #### `mDNS`
 
-If you do not wish to manually keep track of the ESPs IP addresses and ports, you can enable the mDNS feature. This will allow you to connect to the ESPs using the following format: `http://<some_name>.local`. This will only work if you are connected to the same network as the ESPs, and if you have enabled mDNS on your computer. If you are using Windows, you can enable mDNS by following [this guide](/firmware_guide/mdns.html).
+If you do not wish to manually keep track of the ESPs IP addresses and ports, you can enable the mDNS feature. This will allow you to connect to the ESPs using the following format: `http://<some_name>.local`. This will only work if you are connected to the same network as the ESPs, and if you have enabled mDNS on your computer. If you are using Windows, you can enable mDNS by following [this guide](./mdns).
 
 #### `OTA`
 

--- a/vitepress/docs/src/pages/firmware_guide/firmware.md
+++ b/vitepress/docs/src/pages/firmware_guide/firmware.md
@@ -8,4 +8,4 @@ Current testing has been on our own solution called OpenIris, [found here](https
 
 ## How do download this?
 
-[Follow the steps described here](/firmware_guide/setup_vscode)
+[Follow the steps described here](./setup_vscode)

--- a/vitepress/docs/src/pages/firmware_guide/upload_firmware.md
+++ b/vitepress/docs/src/pages/firmware_guide/upload_firmware.md
@@ -91,7 +91,7 @@ Keep in mind while testing and getting set up, the ESP can only have one client,
 
 ## Troubleshooting
 
-If you encountered an issue while following these steps check the [FAQ.](/misc/faq.html)
+If you encountered an issue while following these steps check the [FAQ.](../misc/faq)
 
 If you don't find an answer to your question there ask in **#questions** channel in [the discord](https://discord.gg/kkXYbVykZX), we will be happy to help.
 

--- a/vitepress/docs/src/pages/how_to_build/full_build.md
+++ b/vitepress/docs/src/pages/how_to_build/full_build.md
@@ -15,7 +15,7 @@ import { alerts } from '../../static/alerts'
 
 This will give you a basic overview of the project's status and what to expect currently.
 
-## Step 2: Order all the parts listed on our [Parts list](../parts_list)
+## Step 2: Order all the parts listed on our [Parts list](./parts_list)
 
 Please take note of the fact that hardware still may change, although with more developments it seems like we are going to stick with current hardware.
 
@@ -86,13 +86,13 @@ Slide your ESP into the programmer, and note the USB port goes away from the ESP
 
 ## Step 8: Configure Visual Studio Code and prepare to flash the firmware
 
-Check out our guide on [Setting up VS Code](../firmware_guide/setup_vscode/)
+Check out our guide on [Setting up VS Code](../firmware_guide/setup_vscode)
 
 Once VS Code is set up, move on to the next step.
 
 ## Step 9: Plug in your ESP and flash the firmware
 
-Our guide, [Building and uploading the firmware manually](../firmware_guide/upload_firmware/) has steps on how to do this.
+Our guide, [Building and uploading the firmware manually](../firmware_guide/upload_firmware) has steps on how to do this.
 After it has flashed, make sure you get a video stream in your browser, then power it down and flash your next ESP.
 
 ## Step 10: Connect your power wires to a USB Type-A board
@@ -242,7 +242,7 @@ Use the following diagram:
 
 ## Step 19: 3D print mounts
 
-Head to the 3D printed parts section of the parts list [here.](/how_to_build/parts_list#other-parts)
+Head to the 3D printed parts section of the parts list [here.](./parts_list#other-parts)
 
 Find which parts are for your headset and print them.
 Some may work better or worse, it is recommended to test all of them if there are multiple, print one of each kind.

--- a/vitepress/docs/src/pages/how_to_build/parts_list.md
+++ b/vitepress/docs/src/pages/how_to_build/parts_list.md
@@ -115,7 +115,7 @@ Mounts with a `★` next to them are the reccomended mounts for the respected hm
 
 If you own another headset not listed above, that means there are no mounts designed for them yet. If you have basic skills in modeling or think up a solution to mount cams and emitters, please try to make a mount and then let us in the discord know so it can be added here. Any headset that can fit the camera is potentially compatible. If you are willing, give it a shot to design a mount for the rest of the community.
 
-Check out our basic guide on making your own mount [here.](https://docs.eyetrackvr.dev/creating_your_own_camera_mount/)
+Check out our basic guide on making your own mount [here.](./creating_your_own_mount)
 
 <Alerts :options="alerts.parts_list_six">
     <template v-slot:content>


### PR DESCRIPTION
This PR aims to fix some links leading to 404 page in some circumstances. 

For example, clicking on the Parts List button here: [https://docs.eyetrackvr.dev/how_to_build/full_build](https://docs.eyetrackvr.dev/how_to_build/full_build) will lead to a 404 page, but when clicked on from the second and other steps like so: [https://docs.eyetrackvr.dev/how_to_build/full_build/#step-2-order-all-the-parts-listed-on-our-parts-list](https://docs.eyetrackvr.dev/how_to_build/full_build/#step-2-order-all-the-parts-listed-on-our-parts-list), it works perfectly fine. 

BTW, there's a typo in the path to safety `PDFs` -> `saftey` 

Also, can we somehow test it before merging the PR? I Did test it on my machine and everything works fine, I just want to make sure everything will do so too once deployed

[x] I accept the CLA

Noticed thanks to: \</Konami\>#2183