### PR TITLE
Update the documentation on how to use the new OTA

### DIFF
--- a/vitepress/docs/src/pages/firmware_guide/upload_and_update_firmware.md
+++ b/vitepress/docs/src/pages/firmware_guide/upload_and_update_firmware.md
@@ -63,25 +63,60 @@ OTA stands for `Over The Air`, and it is a way to update your firmware without h
 
 ### How do I use it?
 
-To use OTA, you need to have working firmware on your ESPs first.
+To use OTA, you need to have working firmware on your ESPs first. Follow [the manual building guide](#Building-and-uploading-the-firmware-manually)
 
-Once you have mnually flashed the firmware at least once, you can use the `OTA` environment to upate your ESPs.
+Once you have manually flashed the firmware at least once, you can use the `OTA` environment to upate your ESPs.
 
 ::: tip Coming Soon
-Currently, we only support OTA using `platformio` and `Visual Studio Code`. We are working on a new app, where you can upload your firmware to your ESPs over WiFi straight from the app.
+Currently, we only support OTA using the provided web interface, but we are working on a new app, where you will be able to upload your firmware to your ESPs over WiFi straight from the app.
 :::
 
-To do this, you need to change your environment to the `OTA` version of your working environment.
+#### For firmware versions 1.1.0 and up:
+  
+Since version 1.1.0 we've switched from using OTA via platformio to a more user friendly approach: 
 
-For example, if you have a working `esp32AIThinker` environment, you would change your environment to `esp32AIThinker_OTA`.
+Note: You **don't** have to have the trackers connected to your pc for any of these steps, just powered on and connected to the Wi-Fi. 
 
-Once you have changed your environment, you can upload your firmware to your ESPs using the upload button, as you would normally.
 
-Once you have successfully connected your trackers to your WiFi, you can use OTA to handle all future firmware updates.
+1. Build the firmware using your current environment, if you've switched to an OTA env in the past - repeat those steps but select the environment without the `_OTA` suffix. Next, press the checkmark button to build it without uploading. 
+
+<ImageCard :options="image_settings.upload_firmware_build_button" />
+
+2. Turn on your trackers and wait for them to connect to Wi-Fi
+
+3. Locate their ip or their mDNS name, the default one is: [http://openiristracker.local/](http://openiristracker.local/)
+
+4. Having done that, open [http://\<your-up-or-mdns-name\>:81/update](http://openiristracker.local:81/update)
+
+for example: [http://openiristracker.local/](http://openiristracker.local:81/update) 
+
+This should open a page similar to this: 
+
+<ImageCard :options="image_settings.upload_firmware_webpage" />
+
+Click on the select file button, and navigate to your `Openiris/ESP` directory. 
+
+Once there, open `.pio\build\your-environment` like so: 
+
+<ImageCard :options="image_settings.upload_firmware_webpage_directory" />
+
+You'll find a couple files in there, select the one named `your-environment-vVersion-feature`. 
+
+like this one: 
+
+<ImageCard :options="image_settings.upload_firmware_webpage_directory_file" />
+
+5. Press upload and wait for it to finish. Done!
+
+<ImageCard :options="image_settings.upload_firmware_webpage_upload_finished" />
+
+#### For firmware versions of 1.0.0 and under:
 
 1. Retrieve the IP or mDNS name of the tracker you wish to flash. The IP can be found through network monitoring applications, or by viewing tracker output in a serial monitor.
 2. In the `ini/user_config.ini` file:
    - Put IP or hostname of device into config file
+
+Like so: 
 
 ```ini
 [ota]
@@ -92,6 +127,19 @@ otaserverport = 3232
 ```
 
 3. Change to OTA env
+
+To do that, in visual studio code, locate the uplaod button, next to it will be listed a couple of buttons and your current environment.
+
+ For example, if you have a working `esp32AIThinker` environment, you would change your environment to `esp32AIThinker_OTA`. 
+
+ Click on it.
+
+<ImageCard :options="image_settings.upload_firmware_select_env" />
+
+This will open a list of all avaible environments, select the one that matches your board and has a _OTA part as a suffix 
+
+<ImageCard :options="image_settings.upload_firmware_select_env_dropdown" />
+
 4. Restart the ESPs, they **_must_** be power cycled
 5. Press the upload button to upload the firmware.<br>  
    ![img](https://i.imgur.com/lI3PFVC.png)

--- a/vitepress/docs/src/pages/firmware_guide/upload_and_update_firmware.md
+++ b/vitepress/docs/src/pages/firmware_guide/upload_and_update_firmware.md
@@ -25,7 +25,7 @@ In the case of an FTDI programmer, the steps aren't as easy, so grab [this guide
 
 ## 3. Upload your firmware
 
-- If you are using the OTA method, first make sure the tracker you wish to flash is turned on and connected to your network, then skip to the [OTA section below](#how-do-i-use-it).
+- If you are using the OTA method, skip to the [OTA section below](#how-do-i-use-it).
 
 - Once the firmware has been built, press the upload button to upload the firmware.
 
@@ -73,10 +73,15 @@ Currently, we only support OTA using the provided web interface, but we are work
 
 #### For firmware versions 1.1.0 and up:
   
-Since version 1.1.0 we've switched from using OTA via platformio to a more user friendly approach: 
+Since version 1.1.0 we've switched from using OTA via platformio to a more user-friendly approach.
 
-Note: You **don't** have to have the trackers connected to your pc for any of these steps, just powered on and connected to the Wi-Fi. 
-
+<Alerts :options="alerts.upload_firmware_one">
+    <template v-slot:content>
+        <p>
+           You don't have to have the trackers connected to your pc for any of these steps, just powered on and connected to the Wi-Fi. 
+        </p>
+    </template>
+</Alerts>  
 
 1. Build the firmware using your current environment, if you've switched to an OTA env in the past - repeat those steps but select the environment without the `_OTA` suffix. Next, press the checkmark button to build it without uploading. 
 
@@ -84,9 +89,9 @@ Note: You **don't** have to have the trackers connected to your pc for any of th
 
 2. Turn on your trackers and wait for them to connect to Wi-Fi
 
-3. Locate their ip or their mDNS name, the default one is: [http://openiristracker.local/](http://openiristracker.local/)
+3. Locate their ip or mDNS name. For mDNS, the default is: [http://openiristracker.local/](http://openiristracker.local/)
 
-4. Having done that, open [http://\<your-up-or-mdns-name\>:81/update](http://openiristracker.local:81/update)
+4. Having done that, open [http://\<your-up-or-mdns-name\>:81/update](http://openiristracker.local:81/update) in your browser
 
 for example: [http://openiristracker.local/](http://openiristracker.local:81/update) 
 
@@ -94,9 +99,11 @@ This should open a page similar to this:
 
 <ImageCard :options="image_settings.upload_firmware_webpage" />
 
-Click on the select file button, and navigate to your `Openiris/ESP` directory. 
+Click on the select file button, and navigate to where you cloned the project and then to the `ESP/` directory. 
 
-Once there, open `.pio\build\your-environment` like so: 
+Once there, open `.pio\build\your-environment` like so:
+
+> By default, windows treats files and directories with a dot in front of their name as hidden. To change that - [see here](https://support.microsoft.com/en-us/windows/view-hidden-files-and-folders-in-windows-97fbc472-c603-9d90-91d0-1166d1d9f4b5)
 
 <ImageCard :options="image_settings.upload_firmware_webpage_directory" />
 
@@ -136,7 +143,7 @@ To do that, in visual studio code, locate the uplaod button, next to it will be 
 
 <ImageCard :options="image_settings.upload_firmware_select_env" />
 
-This will open a list of all avaible environments, select the one that matches your board and has a _OTA part as a suffix 
+This will open a list of all available environments, select the one that matches your board and has a _OTA suffix 
 
 <ImageCard :options="image_settings.upload_firmware_select_env_dropdown" />
 
@@ -183,7 +190,7 @@ To update the firmware you'll need to follow a couple of steps.
 
 4.1. If anything went wrong, you can reset everything to the default state using `git reset --hard` and then retyping your credentials
 
-5. Upload your firmware [following steps from the uploading section](./update_platformio.md)
+5. Upload your firmware [following steps from the uploading section](#Building-and-uploading-the-firmware-manually)
 
 ## Troubleshooting
 

--- a/vitepress/docs/src/static/image_settings/index.ts
+++ b/vitepress/docs/src/static/image_settings/index.ts
@@ -222,6 +222,41 @@ const image_settings = {
         alt: "'img of platformio serial monitor'",
         max_width: "max-width: 600px;"
     },
+    upload_firmware_build_button: {
+        url: "https://i.imgur.com/5E5u5Jz.png",
+        alt: "'Selecting platformio environment'",
+        max_width: "max-width: 600px;"
+    },
+    upload_firmware_webpage: {
+        url: "https://i.imgur.com/wMXdZcJ.png",
+        alt: "'Firmware uploading web page'",
+        max_width: "max-width: 600px;"
+    },
+    upload_firmware_webpage_directory: {
+        url: "https://i.imgur.com/KnnB28z.png",
+        alt: "'An example of how the bin file directory looks like'",
+        max_width: "max-width: 600px;"
+    },
+    upload_firmware_webpage_directory_file: {
+        url: "https://i.imgur.com/Ujx3iaG.png",
+        alt: "'An example of how the bin file looks like'",
+        max_width: "max-width: 600px;"
+    },
+    upload_firmware_webpage_upload_finished: {
+        url: "https://i.imgur.com/O2KzHAN.png",
+        alt: "'A finished OTA upload'",
+        max_width: "max-width: 600px;"
+    },
+    upload_firmware_select_env: {
+        url: "https://i.imgur.com/8sn6FSe.png",
+        alt: "'An example of how the popup list of envs looks like'",
+        max_width: "max-width: 600px;"
+    },
+    upload_firmware_select_env_dropdown: {
+        url: "https://i.imgur.com/nRpuBSI.png",
+        alt: "'An example of how the button for selecting env looks like'",
+        max_width: "max-width: 600px;"
+    },
     ant_logo_platformio:{
         url: "https://i.imgur.com/B6zK6n8.png",
         alt: "Platformio logo button",


### PR DESCRIPTION
This pr adds the documentation on how to use the new OTA web page implemented in OpenIris-v1.1.0