### PR TITLE
Fix - add missing link to osc setup page

### DIFF
--- a/vitepress/docs/src/custom/theme/index.ts
+++ b/vitepress/docs/src/custom/theme/index.ts
@@ -61,6 +61,7 @@ const theme = {
             items: [
                 { text: "Installing and setting up the ETVR App", link: "/software_guide/eyetrackvr_app_guide" },
                 { text: "Building the app from source", link: "/software_guide/build_software" },
+                { text: "Setting up OSC recenter/recalibrate", link: "/software_guide/osc_setup" },
             ],
         },
         {


### PR DESCRIPTION
I accidentally forgot to include this file in https://github.com/RedHawk989/EyeTrackVR-Docs/pull/7 which prevented the setting up osc guide from showing up