### PR TITLE
docs: Add note about Wi-Fi-specific settings, fix formatting of Environment list

### DIFF
--- a/vitepress/docs/src/pages/firmware_guide/configure_firmware.md
+++ b/vitepress/docs/src/pages/firmware_guide/configure_firmware.md
@@ -15,6 +15,9 @@ import { alerts } from '../../static/alerts'
 
 <ImageCard :options="image_settings.configure_firmware_two"/>
 
+> **Note**: These settings are applicable only when using Wi-Fi for communication with your computer. If you are using USB, you can skip to reading about [Environments](#environments).
+:::
+
 Replace the placeholder text with your correct SSID (WiFi access point name), and password respectfully.
 
 ::: info
@@ -78,6 +81,7 @@ The firmware supports multiple environments. This means that we have full suppor
 - `wrooms3QIOUSB` - For FREENOVE-ESP32-S3 (*wired mode*, for boards with octal flash)
 - `xiaosenses3_release` - For SeedStudio's XAIO ESP32-S3 Sense (*wireless mode*)
 - `xiaosenses3_USB_release` - For SeedStudio's XAIO ESP32-S3 Sense (*wired mode*)
+
 Each environment has a `debug` and `release` configuration. The `debug` configuration is for debugging, and the `release` configuration is for production. The `debug` configuration is not recommended for production, as it will use more memory, and will be slower. However we recommend using the `debug` configuration for initial configuration and testing, as it will be easier to debug, for you and for us. Once you are confident that the firmware is working correctly, you can switch to the `release` configuration.
 
 The `debug` configuration will print out debug messages to the serial port. The `release` configuration will not print out debug messages to the serial port, and will only print errors. This will save memory, and will make the firmware faster.

--- a/vitepress/docs/src/pages/firmware_guide/configure_firmware.md
+++ b/vitepress/docs/src/pages/firmware_guide/configure_firmware.md
@@ -15,7 +15,8 @@ import { alerts } from '../../static/alerts'
 
 <ImageCard :options="image_settings.configure_firmware_two"/>
 
-> **Note**: These settings are applicable only when using Wi-Fi for communication with your computer. If you are using USB, you can skip to reading about [Environments](#environments).
+::: info
+These settings are applicable only when using Wi-Fi for communication with your computer. If you are using USB, you can skip to reading about [Environments](#environments).
 :::
 
 Replace the placeholder text with your correct SSID (WiFi access point name), and password respectfully.


### PR DESCRIPTION
This updates the firmware guide page to add a note that the ini configuration is Wi-Fi-specific, and fixes the list of environments so that the paragraph of text after it isn't blended into the list.