### PR TITLE
Filled-in the `Camera Params` section of the rest_api page

### DIFF
--- a/vitepress/docs/src/pages/firmware_guide/rest_api.md
+++ b/vitepress/docs/src/pages/firmware_guide/rest_api.md
@@ -161,7 +161,3 @@ typedef enum {
 | `quality` |  The JPEG quality level: 1-63? | **Smaller** number = higher quality, more latency and less fps |
 | `brightness` | The `agc_gain` of the camera. | Larger number = more bright. |
 
-
-::: tip Uncertain Values
-These values and their descriptions were reverse-engineered from the OpenIRIS C++ code and trial-and-error, so they would benefit from review by someone who understands their meaning.
-:::

--- a/vitepress/docs/src/pages/firmware_guide/rest_api.md
+++ b/vitepress/docs/src/pages/firmware_guide/rest_api.md
@@ -153,6 +153,15 @@ typedef enum {
 
 ### Camera Params
 
-::: tip Coming Soon
-We are currently working on this section of documentation.
+| Param | Description | Value Effect |
+| :---: | :---------: | :---------: |
+| `vflip` | Whether to flip the frames vertically. | 0 or 1 |
+| `framesize` | A value between 0-7 indicating the frame resolution. | Larger number - higher resolution. |
+| `href` | Unknown. | ? |
+| `quality` |  The JPEG quality level: 1-63? | **Smaller** number = higher quality, more latency and less fps |
+| `brightness` | The `agc_gain` of the camera. | Larger number = more bright. |
+
+
+::: tip Uncertain Values
+These values and their descriptions were reverse-engineered from the OpenIRIS C++ code and trial-and-error, so they would benefit from review by someone who understands their meaning.
 :::

--- a/vitepress/docs/src/pages/firmware_guide/rest_api.md
+++ b/vitepress/docs/src/pages/firmware_guide/rest_api.md
@@ -157,7 +157,7 @@ typedef enum {
 | :---: | :---------: | :---------: |
 | `vflip` | Whether to flip the frames vertically. | 0 or 1 |
 | `framesize` | A value between 0-7 indicating the frame resolution. | Larger number - higher resolution. |
-| `href` | Unknown. | ? |
+| `hflip` | Whether to flip the frames horizontally. | 0 or 1 |
 | `quality` |  The JPEG quality level: 1-63? | **Smaller** number = higher quality, more latency and less fps |
 | `brightness` | The `agc_gain` of the camera. | Larger number = more bright. |
 


### PR DESCRIPTION
I replaced the "Coming soon" note with a table that I developed for myself via experimentation and reverse-engineering the OpenIris code. Also left footnote explaining that an expert should check these values.

I think changing the camera parameters is one of the most important features of the REST API, so having a table instead of a coming soon message should help users get started.