### PR TITLE
fix(docs): remove open source, it is source-available now.

### DIFF
--- a/vitepress/docs/fr/src/pages/about.md
+++ b/vitepress/docs/fr/src/pages/about.md
@@ -44,10 +44,6 @@ import { members, contributors } from '../static/members'
         (pas toutes aussi soignés que les autres) que l'on donnes pour que d'autres personnes puisses les utiliser<br>
         <br>
         On espère que tu trouvera quleque chose d'utile ici aussi<br>
-        <br>
-        On est militant du modèle<a class="custom-links" href="https://fr.wikipedia.org/wiki/Open_source" target="_blank">open source</a>.<br>
-        <br>
-        C'est donc pour ça que nous nous éfforçons à faire en sorte que notre travail soit ouvert aux autres pour être regardé, reproduit et/ou réutilisé.
     </template>
   </VPTeamPageSection>
 </VPTeamPage>

--- a/vitepress/docs/fr/src/pages/getting_started/intro.md
+++ b/vitepress/docs/fr/src/pages/getting_started/intro.md
@@ -7,7 +7,7 @@ import { image_settings } from '../../static/image_settings'
 
 # EyeTrackVR {.text-3xl .font-bold .underline .text-[#ab5ac7]}
 
-Une plateforme de suivi des yeux open source et *abordable* pour les jeux sociaux VR via le protocole `OSC` et `UDP`.
+Une plateforme de suivi oculaire orientée vers la communauté *abordable* pour les jeux sociaux VR via le protocole `OSC` et `UDP`.
 
 <Alerts :options="alerts.user_warning">
     <template v-slot:content>

--- a/vitepress/docs/fr/src/pages/index.md
+++ b/vitepress/docs/fr/src/pages/index.md
@@ -3,7 +3,7 @@ layout: home
 
 hero:
   name: Doccumentation de EyeTrackVR
-  text: Un système de suivi des yeux open source et abordable.
+  text: Un système de suivi oculaire abordable et axé sur la communauté.
   image:
     src: /logo_light.png
     alt: ETRVR logo
@@ -17,8 +17,8 @@ hero:
       link: https://github.com/EyeTrackVR/EyeTrackVR
 features:
   - icon: ⚡️
-    title: Open Source
-    details: EyeTrackVR est totalement open source gratuit d'utilisation.
+    title: Source Available
+    details: le code source est disponible pour une utilisation non commerciale.
   - icon: 🎉
     title: Communautaire
     details: EyeTrackVR est construit par toi pour toi.

--- a/vitepress/docs/src/pages/about.md
+++ b/vitepress/docs/src/pages/about.md
@@ -43,10 +43,6 @@ import { members, contributors } from '../static/members'
         The <a class="custom-links" href="/intro" target="_blank">guides</a> on this website include some of our teams own notes (not all of them are polished) that we disclose for other people to use.<br>
         <br>
         Here, we hope you may find something useful to you.<br>
-        <br>
-        We advocate the <a class="custom-links" href="https://en.wikipedia.org/wiki/Open-source_model" target="_blank">Open Source model</a>.<br>
-        <br>
-        This is why we strive to make our work open to other people for consultation, replication and reuse.
     </template>
   </VPTeamPageSection>
 </VPTeamPage>

--- a/vitepress/docs/src/pages/getting_started/intro.md
+++ b/vitepress/docs/src/pages/getting_started/intro.md
@@ -7,7 +7,7 @@ import { image_settings } from '../../static/image_settings'
 
 # EyeTrackVR {.text-3xl .font-bold .underline .text-[#ab5ac7]}
 
-Open source and *affordable* VR eye tracker platform for Social VR Games via `OSC` and `UDP` protocol.
+A community oriented and *affordable* VR eye tracker platform for Social VR Games via `OSC` and `UDP` protocol.
 
 ### Welcome to the EyetrackVR documentation website. Here you will find all avalable documentation regauding building, development, and other resources related to this project.
 

--- a/vitepress/docs/src/pages/index.md
+++ b/vitepress/docs/src/pages/index.md
@@ -6,7 +6,7 @@ head:
       content: EyeTrackVR ETVR VR Virtual Reality Eye Tracking VRChat Social VR Games VR Game VR Games VRChat Avatar VRChat Avatars VRChat Eye Tracking VRChat Eye Tracking Avatar VRChat Eye Tracking Avatars
 hero:
   name: EyeTrackVR Docs
-  text: Open-source and affordable VR eye tracking.
+  text: Community oriented and affordable VR eye tracking.
   image:
     src: /logo_light.png
     alt: ETVR logo
@@ -20,8 +20,8 @@ hero:
       link: https://github.com/EyeTrackVR/EyeTrackVR
 features:
   - icon: ⚡️
-    title: Open Source
-    details: fully open source and free to use.
+    title: Source Available
+    details: source code available for noncommercial use.
   - icon: 🎉
     title: Community Driven
     details: built by you for you.

--- a/vitepress/docs/src/static/faq/index.ts
+++ b/vitepress/docs/src/static/faq/index.ts
@@ -2,7 +2,7 @@ const faq = {
     faq: [
         {
             question: "What is the goal of this project?",
-            answer: "To provide an open source, affordable VR eye tracker for Social games like VRChat as well as provide an open eye tracking platform.",
+            answer: "To provide an community oriented, affordable VR eye tracker for Social games like VRChat as well as provide an open eye tracking platform.",
             hyper_link: "",
             link_description: "",
         },


### PR DESCRIPTION
https://opensource.org/osd. I suggest using the term "source-available" or "business-source". Source available is probably the preferable term. I also used the term "Community oriented" instead in some places where it made more sense to talk about goals rather than licenses.